### PR TITLE
chore: use self-hosted ironbank Go image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ help: ## Show the help
 .PHONY: it
 it: build build-tests ## Initialize the development environment
 
-GOLANG_VERSION=1.18
+GOLANG_VERSION=1.17.9
 DOCKER_REPOSITORY=onebrief
 GOTENBERG_VERSION=7.5.2
 GOTENBERG_USER_GID=1001

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ help: ## Show the help
 it: build build-tests ## Initialize the development environment
 
 GOLANG_VERSION=1.18
-DOCKER_REPOSITORY=gotenberg
-GOTENBERG_VERSION=snapshot
+DOCKER_REPOSITORY=onebrief
+GOTENBERG_VERSION=7.5.2
 GOTENBERG_USER_GID=1001
 GOTENBERG_USER_UID=1001
 NOTO_COLOR_EMOJI_VERSION=v2.034 # See https://github.com/googlefonts/noto-emoji/releases.
@@ -16,7 +16,8 @@ GOLANGCI_LINT_VERSION=v1.45.0 # See https://github.com/golangci/golangci-lint/re
 
 .PHONY: build
 build: ## Build the Gotenberg's Docker image
-	docker build \
+	docker buildx build \
+	--platform linux/amd64 \
 	--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 	--build-arg GOTENBERG_VERSION=$(GOTENBERG_VERSION) \
 	--build-arg GOTENBERG_USER_GID=$(GOTENBERG_USER_GID) \
@@ -28,7 +29,7 @@ build: ## Build the Gotenberg's Docker image
 
 GOTENBERG_GRACEFUL_SHUTDOWN_DURATION=30s
 API_PORT=3000
-API_PORT_FROM_ENV=
+API_PORT_FROM_ENV=PORT
 API_TIMEOUT=30s
 API_ROOT_PATH=/
 API_TRACE_HEADER=Gotenberg-Trace

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ GOLANGCI_LINT_VERSION=v1.45.0 # See https://github.com/golangci/golangci-lint/re
 .PHONY: build
 build: ## Build the Gotenberg's Docker image
 	docker buildx build \
+	--load \
 	--platform linux/amd64 \
 	--build-arg GOLANG_VERSION=$(GOLANG_VERSION) \
 	--build-arg GOTENBERG_VERSION=$(GOTENBERG_VERSION) \

--- a/README.md
+++ b/README.md
@@ -10,6 +10,29 @@
 Gotenberg provides a developer-friendly API to interact with powerful tools like Chromium and LibreOffice for converting 
 numerous document formats (HTML, Markdown, Word, Excel, etc.) into PDF files, and more!
 
+## Onebrief deployment to Heroku/GitHub
+
+We deploy Gotenberg to Heroku for ease of use in both staging/production but also for developers to get their environment running without having to host it locally. This is how to deploy a new version of Gotenberg to both GitHub Packages and Heroku.
+
+If you don't already have a GitHub personal access token, you can generate one [here](https://github.com/settings/tokens/new)
+
+### Log in to GitHub Packages
+```bash
+$ export CR_PAT=TOKEN_HERE
+$ echo $CR_PAT | docker login ghcr.io -u USERNAME --password-stdin
+```
+### Log in to Heroku via CLI (download [here](https://devcenter.heroku.com/articles/heroku-cli))
+
+```bash
+$ heroku container:login
+```
+
+### Build and release new version
+```bash
+$ make release
+```
+
+
 ## Quick Start
 
 Open a terminal and run the following command:

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /home
 COPY go.mod go.sum ./
 
 RUN go mod download &&\
-    go mod verify
+  go mod verify
 
 # Copy the source code.
 COPY cmd ./cmd
@@ -31,10 +31,10 @@ FROM debian:11-slim
 ARG GOTENBERG_VERSION
 
 LABEL author="Julien Neuhart" \
-      description="A Docker-powered stateless API for PDF files." \
-      github="https://github.com/gotenberg/gotenberg" \
-      version="$GOTENBERG_VERSION" \
-      website="https://gotenberg.dev"
+  description="A Docker-powered stateless API for PDF files." \
+  github="https://github.com/gotenberg/gotenberg" \
+  version="$GOTENBERG_VERSION" \
+  website="https://gotenberg.dev"
 
 # Improve fonts subpixel hinting and smoothing.
 # Credits:
@@ -57,98 +57,98 @@ ARG PDFTK_VERSION
 COPY build/install-chromium.sh /tmp/install-chromium.sh
 
 RUN \
-    # Create a non-root user.
-    # All processes in the Docker container will run with this dedicated user.
-    groupadd --gid "$GOTENBERG_USER_GID" gotenberg &&\
-    useradd --uid "$GOTENBERG_USER_UID" --gid gotenberg --shell /bin/bash --home /home/gotenberg --no-create-home gotenberg &&\
-    mkdir /home/gotenberg &&\
-    chown gotenberg: /home/gotenberg &&\
-    # Install dependencies required for the next instructions or debugging.
-    # Note: tini is a helper for reaping zombie processes.
-    apt-get update -qq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg htop tini python3 default-jre-headless &&\
-    ln -s /usr/bin/htop /usr/bin/top &&\
-    # Install fonts.
-    # Credits:
-    # https://github.com/arachnys/athenapdf/blob/master/cli/Dockerfile.
-    # https://help.accusoft.com/PrizmDoc/v12.1/HTML/Installing_Asian_Fonts_on_Ubuntu_and_Debian.html.
-    curl -o ./ttf-mscorefonts-installer_3.8_all.deb http://httpredir.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.8_all.deb &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
-    ./ttf-mscorefonts-installer_3.8_all.deb \
-    culmus \
-    fonts-beng \
-    fonts-hosny-amiri \
-    fonts-lklug-sinhala \
-    fonts-lohit-guru \
-    fonts-lohit-knda \
-    fonts-samyak-gujr \
-    fonts-samyak-mlym \
-    fonts-samyak-taml \
-    fonts-sarai \
-    fonts-sil-abyssinica \
-    fonts-sil-padauk \
-    fonts-telu \
-    fonts-thai-tlwg \
-    ttf-wqy-zenhei \
-    fonts-arphic-ukai \
-    fonts-arphic-uming \
-    fonts-ipafont-mincho \
-    fonts-ipafont-gothic \
-    fonts-unfonts-core \
-    # LibreOffice recommends.
-    fonts-crosextra-caladea \
-    fonts-crosextra-carlito \
-    fonts-dejavu \
-    fonts-dejavu-extra \
-    fonts-liberation \
-    fonts-liberation2 \
-    fonts-linuxlibertine \
-    fonts-noto-cjk \
-    fonts-noto-core \
-    fonts-noto-mono \
-    fonts-noto-ui-core \
-    fonts-sil-gentium \
-    fonts-sil-gentium-basic &&\
-    rm -f ./ttf-mscorefonts-installer_3.8_all.deb &&\
-    # Add Color and Black-and-White Noto emoji font.
-    # Credits:
-    # https://github.com/gotenberg/gotenberg/pull/325.
-    # https://github.com/googlefonts/noto-emoji.
-    curl -Ls "https://github.com/googlefonts/noto-emoji/raw/$NOTO_COLOR_EMOJI_VERSION/fonts/NotoColorEmoji.ttf" -o /usr/local/share/fonts/NotoColorEmoji.ttf &&\
-    # Install Google Chrome / Chromium.
-    /tmp/install-chromium.sh &&\
-    # Install LibreOffice.
-    # Note: we use the bullseye-backports distribution to get the latest LibreOffice version.
-    # See:
-    # https://github.com/gotenberg/gotenberg/pull/322.
-    # https://github.com/gotenberg/gotenberg/issues/403.
-    echo "deb https://httpredir.debian.org/debian/ bullseye-backports main contrib non-free" >> /etc/apt/sources.list &&\
-    apt-get update -qq &&\
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t bullseye-backports libreoffice &&\
-    # Download unoconv (Python script).
-    curl -Ls https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv -o /usr/bin/unoconv &&\
-    chmod +x /usr/bin/unoconv &&\
-    # unoconv will look for the Python binary, which has to be at version 3.
-    ln -s /usr/bin/python3 /usr/bin/python &&\
-    # Download PDFtk.
-    # See https://github.com/gotenberg/gotenberg/pull/273. \
-    curl -o /usr/bin/pdftk-all.jar "https://gitlab.com/api/v4/projects/5024297/packages/generic/pdftk-java/$PDFTK_VERSION/pdftk-all.jar" &&\
-    chmod a+x /usr/bin/pdftk-all.jar &&\
-    # Download QPDF.
-    DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends qpdf &&\
-    # See https://github.com/nextcloud/docker/issues/380.
-    mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\
-    # Cleanup.
-    # Note: the Debian image does automatically a clean after each install thanks to a hook.
-    # Therefore, there is no need for apt-get clean.
-    # See https://stackoverflow.com/a/24417119/3248473.
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
-    # Print versions of main dependencies.
-    chromium --version &&\
-    libreoffice --version &&\
-    unoconv --version &&\
-    pdftk --version &&\
-    qpdf --version
+  # Create a non-root user.
+  # All processes in the Docker container will run with this dedicated user.
+  groupadd --gid "$GOTENBERG_USER_GID" gotenberg &&\
+  useradd --uid "$GOTENBERG_USER_UID" --gid gotenberg --shell /bin/bash --home /home/gotenberg --no-create-home gotenberg &&\
+  mkdir /home/gotenberg &&\
+  chown gotenberg: /home/gotenberg &&\
+  # Install dependencies required for the next instructions or debugging.
+  # Note: tini is a helper for reaping zombie processes.
+  apt-get update -qq &&\
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends curl gnupg htop tini python3 default-jre-headless &&\
+  ln -s /usr/bin/htop /usr/bin/top &&\
+  # Install fonts.
+  # Credits:
+  # https://github.com/arachnys/athenapdf/blob/master/cli/Dockerfile.
+  # https://help.accusoft.com/PrizmDoc/v12.1/HTML/Installing_Asian_Fonts_on_Ubuntu_and_Debian.html.
+  curl -o ./ttf-mscorefonts-installer_3.8_all.deb http://httpredir.debian.org/debian/pool/contrib/m/msttcorefonts/ttf-mscorefonts-installer_3.8_all.deb &&\
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends \
+  ./ttf-mscorefonts-installer_3.8_all.deb \
+  culmus \
+  fonts-beng \
+  fonts-hosny-amiri \
+  fonts-lklug-sinhala \
+  fonts-lohit-guru \
+  fonts-lohit-knda \
+  fonts-samyak-gujr \
+  fonts-samyak-mlym \
+  fonts-samyak-taml \
+  fonts-sarai \
+  fonts-sil-abyssinica \
+  fonts-sil-padauk \
+  fonts-telu \
+  fonts-thai-tlwg \
+  ttf-wqy-zenhei \
+  fonts-arphic-ukai \
+  fonts-arphic-uming \
+  fonts-ipafont-mincho \
+  fonts-ipafont-gothic \
+  fonts-unfonts-core \
+  # LibreOffice recommends.
+  fonts-crosextra-caladea \
+  fonts-crosextra-carlito \
+  fonts-dejavu \
+  fonts-dejavu-extra \
+  fonts-liberation \
+  fonts-liberation2 \
+  fonts-linuxlibertine \
+  fonts-noto-cjk \
+  fonts-noto-core \
+  fonts-noto-mono \
+  fonts-noto-ui-core \
+  fonts-sil-gentium \
+  fonts-sil-gentium-basic &&\
+  rm -f ./ttf-mscorefonts-installer_3.8_all.deb &&\
+  # Add Color and Black-and-White Noto emoji font.
+  # Credits:
+  # https://github.com/gotenberg/gotenberg/pull/325.
+  # https://github.com/googlefonts/noto-emoji.
+  curl -Ls "https://github.com/googlefonts/noto-emoji/raw/$NOTO_COLOR_EMOJI_VERSION/fonts/NotoColorEmoji.ttf" -o /usr/local/share/fonts/NotoColorEmoji.ttf &&\
+  # Install Google Chrome / Chromium.
+  /tmp/install-chromium.sh &&\
+  # Install LibreOffice.
+  # Note: we use the bullseye-backports distribution to get the latest LibreOffice version.
+  # See:
+  # https://github.com/gotenberg/gotenberg/pull/322.
+  # https://github.com/gotenberg/gotenberg/issues/403.
+  echo "deb https://httpredir.debian.org/debian/ bullseye-backports main contrib non-free" >> /etc/apt/sources.list &&\
+  apt-get update -qq &&\
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends -t bullseye-backports libreoffice &&\
+  # Download unoconv (Python script).
+  curl -Ls https://raw.githubusercontent.com/dagwieers/unoconv/master/unoconv -o /usr/bin/unoconv &&\
+  chmod +x /usr/bin/unoconv &&\
+  # unoconv will look for the Python binary, which has to be at version 3.
+  ln -s /usr/bin/python3 /usr/bin/python &&\
+  # Download PDFtk.
+  # See https://github.com/gotenberg/gotenberg/pull/273. \
+  curl -o /usr/bin/pdftk-all.jar "https://gitlab.com/api/v4/projects/5024297/packages/generic/pdftk-java/$PDFTK_VERSION/pdftk-all.jar" &&\
+  chmod a+x /usr/bin/pdftk-all.jar &&\
+  # Download QPDF.
+  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends qpdf &&\
+  # See https://github.com/nextcloud/docker/issues/380.
+  mkdir -p /usr/share/man/man1mkdir -p /usr/share/man/man1 &&\
+  # Cleanup.
+  # Note: the Debian image does automatically a clean after each install thanks to a hook.
+  # Therefore, there is no need for apt-get clean.
+  # See https://stackoverflow.com/a/24417119/3248473.
+  rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* &&\
+  # Print versions of main dependencies.
+  chromium --version &&\
+  libreoffice --version &&\
+  unoconv --version &&\
+  pdftk --version &&\
+  qpdf --version
 
 # Copy the Gotenberg binary from the builder stage.
 COPY --from=builder /home/gotenberg /usr/bin/
@@ -168,4 +168,5 @@ WORKDIR /home/gotenberg
 EXPOSE 3000
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
+# CMD [ "gotenberg", "--api-port-from-env", "PORT" ]
 CMD [ "gotenberg" ]

--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -4,7 +4,9 @@ ARG GOLANG_VERSION
 # Note: we have to repeat ARG instructions in each build stage that uses them.
 ARG GOTENBERG_VERSION
 
-FROM golang:$GOLANG_VERSION AS builder
+FROM ghcr.io/onebrief/ironbank/google/golang:1.17.9 AS builder
+# When in prod we can use their repo (?)
+# FROM registry1.dso.mil/ironbank/google/golang:1.17.9 AS builder
 
 ENV CGO_ENABLED 0
 
@@ -20,6 +22,9 @@ RUN go mod download &&\
 # Copy the source code.
 COPY cmd ./cmd
 COPY pkg ./pkg
+
+# Switch to root user for build
+USER root
 
 # Build the binary.
 ARG GOTENBERG_VERSION

--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -168,4 +168,4 @@ WORKDIR /home/gotenberg
 EXPOSE 3000
 
 ENTRYPOINT [ "/usr/bin/tini", "--" ]
-CMD [ "gotenberg" ]
+CMD [ "gotenberg", "--api-port-from-env", "PORT", "--uno-listener-restart-threshold=0" ]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,7 +3,7 @@
 set -e
 
 DOCKER_REPO_GH="ghcr.io/onebrief"
-DOCKER_REPO_HEROKU="registry.heroku.com/gotenberg-test/web"
+DOCKER_REPO_HEROKU="registry.heroku.com/bc-gotenberg/web"
 
 GOLANG_VERSION="$1"
 GOTENBERG_VERSION="$2"
@@ -34,7 +34,7 @@ docker buildx build \
   -t "$DOCKER_REPO_GH/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]}" \
   -t "$DOCKER_REPO_HEROKU" \
   --push \
-  -f build/Dockerfile .
+  -f build/Dockerfile.bc .
 
 # release app on heroku
-heroku container:release web --app gotenberg-test
+heroku container:release web --app bc-gotenberg

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+DOCKER_REPO_GH="ghcr.io/onebrief"
+DOCKER_REPO_HEROKU="registry.heroku.com/gotenberg-test/web"
+
 GOLANG_VERSION="$1"
 GOTENBERG_VERSION="$2"
 GOTENBERG_USER_GID="$3"
@@ -27,27 +30,11 @@ docker buildx build \
   --build-arg NOTO_COLOR_EMOJI_VERSION="$NOTO_COLOR_EMOJI_VERSION" \
   --build-arg PDFTK_VERSION="$PDFTK_VERSION" \
   --platform linux/amd64 \
-  --platform linux/arm64 \
-  --platform linux/arm/v7 \
-  --platform linux/386 \
-  -t "$DOCKER_REPOSITORY/gotenberg:latest" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}.${SEMVER[1]}" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]}" \
+  -t "$DOCKER_REPO_GH/gotenberg:latest" \
+  -t "$DOCKER_REPO_GH/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]}" \
+  -t "$DOCKER_REPO_HEROKU" \
   --push \
   -f build/Dockerfile .
 
-# Cloud Run variant.
-docker buildx build \
-  --build-arg DOCKER_REPOSITORY="$DOCKER_REPOSITORY" \
-  --build-arg GOTENBERG_VERSION="$GOTENBERG_VERSION" \
-  --platform linux/amd64 \
-  --platform linux/arm64 \
-  --platform linux/arm/v7 \
-  --platform linux/386 \
-  -t "$DOCKER_REPOSITORY/gotenberg:latest-cloudrun" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}-cloudrun" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}.${SEMVER[1]}-cloudrun" \
-  -t "$DOCKER_REPOSITORY/gotenberg:${SEMVER[0]}.${SEMVER[1]}.${SEMVER[2]}-cloudrun" \
-  --push \
-  -f build/Dockerfile.cloudrun .
+# release app on heroku
+heroku container:release web --app gotenberg-test


### PR DESCRIPTION
## What does this PR change?

Use Ironbank's hardened image of Go @ 1.17.9

Currently it is self hosted @ our GHCR repo but in prod when building we can replace with Ironbank's repo if possible

## How does this benefit our customers or dev team?

This allows our Gotenberg image to use an already-hardened Go base image

## How to test

## Misc.

## Author checklist
- [x] Reviewed my own PR
