### PR TITLE
ci: Fix pushing the docker image to GHCR

### DIFF
--- a/.github/workflows/continuous_delivery.yml
+++ b/.github/workflows/continuous_delivery.yml
@@ -16,8 +16,9 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@v2
       - name: Log in to Docker Hub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
+          registry: ghcr.io
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push Docker image


### PR DESCRIPTION
Allow the CI to login and push to the docker image to GHCR