### PR TITLE
chore: remove multi arch for docker build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: |
-            linux/amd64,
-            linux/arm64,
-            linux/386,
-            linux/arm/v7
+            linux/amd64

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,9 +21,6 @@ docker buildx build \
   --build-arg GOLANG_VERSION="$GOLANG_VERSION" \
   --build-arg GOTENBERG_VERSION="$GOTENBERG_VERSION" \
   --platform linux/amd64 \
-  --platform linux/arm64 \
-  --platform linux/386 \
-  --platform linux/arm/v7 \
   -t "$DOCKER_REPO_GH/gotenberg:latest" \
   -t "$DOCKER_REPO_GH/gotenberg:${SEMVER[0]}" \
   -t "$DOCKER_REPO_GH/gotenberg:${SEMVER[0]}.${SEMVER[1]}" \


### PR DESCRIPTION
Removes the multi architecture build for docker because only x86_64 (linux/amd64) is available from Chainguard at the moment and the build fails if we specify anything else.