### PR TITLE
fix: build gotenberg with golang 1.24.2 [DEV-456]

### DIFF
--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.24.0
+ARG GOLANG_VERSION=1.24.2
 ARG GOTENBERG_VERSION=8.20.1
 ARG BASE_IMAGE=harbor.onebrief.tools/cgr.dev/onebrief.com/gotenberg
 ARG UNOCONVERTER_BIN_PATH=/usr/bin/unoconv


### PR DESCRIPTION
Build gotenberg with golang 1.24.2.