### PR TITLE
chore: pin action dependencies to SHAs, update Fortify action [DEV-500]

### DIFF
--- a/.github/actions/build-test-push/action.yml
+++ b/.github/actions/build-test-push/action.yml
@@ -39,16 +39,16 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         username: ${{ inputs.docker_hub_username }}
         password: ${{ inputs.docker_hub_password }}

--- a/.github/actions/merge/action.yml
+++ b/.github/actions/merge/action.yml
@@ -25,16 +25,16 @@ runs:
   using: composite
   steps:
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
 
     - name: Check out code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
     - name: Log in to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
       with:
         username: ${{ inputs.docker_hub_username }}
         password: ${{ inputs.docker_hub_password }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,40 +30,40 @@ jobs:
           - x86
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version: 1.23.3
           cache: false
 
       - name: Login to harbor.onebrief.tools
-        uses: docker/login-action@v2
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: harbor.onebrief.tools
           username: ${{ secrets.HARBOR_USER }}
           password: ${{ secrets.HARBOR_TOKEN }}
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@4fc4975a852c8cd99761e2de1f4ba73402e44dd9 #v4.0.3
         with:
           role-to-assume: arn:aws:iam::183613197217:role/GitHubAction-AssumeRoleWithAction-ECR-ReadOnly
           role-session-name: GitHub_to_AWS_via_FederatedOIDC
           aws-region: us-east-1
 
       - name: Login to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 #v2.0.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 #v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
 
       - name: Docker Metadata
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
         with:
           images: |
             harbor.onebrief.tools/onebrief/gotenberg
@@ -77,7 +77,7 @@ jobs:
 
       - name: Docker Build
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1 #v6.16.0
         with:
           context: .
           file: ./build/Dockerfile.bc
@@ -104,14 +104,14 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
         with:
           name: digests-${{ steps.setout.outputs.digestname }}
           path: /tmp/digests/*
           if-no-files-found: error
           retention-days: 1
 
-      - uses: anchore/scan-action@7e1d7c7efead0a0d601d6db77ef537817e3ca6a8
+      - uses: anchore/scan-action@2c901ab7378897c01b8efaa2d0c9bf519cc64b9e #v6.2.0
         if: ${{ matrix.type == 'x86' }}
         id: scan
         continue-on-error: true
@@ -123,7 +123,7 @@ jobs:
 
       - name: upload Anchore scan SARIF report
         if: ${{ matrix.type == 'x86' }}
-        uses: github/codeql-action/upload-sarif@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a
+        uses: github/codeql-action/upload-sarif@7e3036b9cd87fc26dd06747b7aa4b96c27aaef3a #v3.28.17
         with:
           sarif_file: ${{ steps.scan.outputs.sarif }}
 
@@ -134,7 +134,7 @@ jobs:
       - build-docker-image
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Set outputs
         id: calculate
@@ -145,17 +145,17 @@ jobs:
           echo "digestname=${reponame/\//-}" >> $GITHUB_OUTPUT
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 #v4.3.0
         with:
           path: /tmp/digests
           pattern: digests-${{ steps.calculate.outputs.digestname }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 #v3.10.0
 
       - name: Login to container registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 #v3.4.0
         with:
           registry: harbor.onebrief.tools
           username: ${{ secrets.HARBOR_USER }}
@@ -163,7 +163,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804 #v5.7.0
         with:
           images: harbor.onebrief.tools/onebrief/gotenberg
           tags: |

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -16,7 +16,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build and push
         id: build_push
@@ -36,7 +36,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build and push
         id: build_push
@@ -56,7 +56,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build and push
         id: build_push
@@ -76,7 +76,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build and push
         id: build_push
@@ -98,7 +98,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Merge
         uses: ./.github/actions/merge

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version-file: go.mod
 
       - name: Run linters
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa #v7.0.1
         with:
           version: v2.0.2
 
@@ -38,10 +38,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4.4.0
         with:
           node-version-file: .node-version
 
@@ -59,10 +59,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 #v5.5.0
         with:
           go-version-file: go.mod
 
@@ -80,7 +80,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -103,7 +103,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -126,7 +126,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -149,7 +149,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -171,7 +171,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Merge
         uses: ./.github/actions/merge
@@ -198,7 +198,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -220,7 +220,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -242,7 +242,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -264,7 +264,7 @@ jobs:
       tags_cloud_run: ${{ steps.build_test_push.outputs.tags_cloud_run }}
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build, test and push
         id: build_test_push
@@ -285,7 +285,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Merge
         uses: ./.github/actions/merge

--- a/.github/workflows/pull-request-cleanup.yml
+++ b/.github/workflows/pull-request-cleanup.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Cleanup
         uses: ./.github/actions/clean

--- a/.github/workflows/run-sast-scan.yml
+++ b/.github/workflows/run-sast-scan.yml
@@ -41,33 +41,6 @@ jobs:
           FOD_USER: ${{ secrets.FOD_USER }}
           FOD_PASSWORD: ${{ secrets.FOD_PAT }}
           FOD_RELEASE: ${{ secrets.FOD_RELEASE_ID }}
-
-      # Java 8 required by ScanCentral Client and FoD Uploader(Univeral CI Tool)
-    #   - name: Setup Java
-    #     uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1
-    #     with:
-    #       java-version: 1.8
-      
-    #   # ScanCentral Client documentation is located at https://www.microfocus.com/documentation/fortify-software-security-center/ 
-    #   - name: Download Fortify ScanCentral Client
-    #     uses: fortify/gha-setup-scancentral-client@v1
-    #   - name: Package Code + Dependencies
-    #     run: scancentral package -bt none -o package.zip
-      
-    #   # Start Fortify on Demand SAST scan and wait until results complete. For more information on FoDUploader commands, see https://github.com/fod-dev/fod-uploader-java
-    #   - name: Download Fortify on Demand Universal CI Tool
-    #     uses: fortify/gha-setup-fod-uploader@v1
-    #   - name: Perform SAST Scan
-    #     run: java -jar $FOD_UPLOAD_JAR -z package.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_UPLOADER_NOTES"
-    #     env: 
-    #       FOD_TENANT: ${{ secrets.FOD_TENANT }}  
-    #       FOD_USER: ${{ secrets.FOD_USER }}
-    #       FOD_PAT: ${{ secrets.FOD_PAT }}
-    #       FOD_RELEASE_ID: ${{ secrets.FOD_RELEASE_ID }}
-    #       FOD_URL: "https://ams.fortify.com/"
-    #       FOD_API_URL: "https://api.ams.fortify.com/"
-    #       FOD_UPLOADER_OPTS: "-ep 2 -pp 0 -I 1 -apf"
-    #       FOD_UPLOADER_NOTES: 'Triggered by GitHub Actions (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
       
       ###
       # These remaining steps require GitHub Enterprise

--- a/.github/workflows/run-sast-scan.yml
+++ b/.github/workflows/run-sast-scan.yml
@@ -23,39 +23,51 @@ jobs:
 
     steps:
       - name: Check Out Source Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           # Fetch at least the immediate parents so that if this is a pull request then we can checkout the head.
           fetch-depth: 2
       # If this run was triggered by a pull request event, then checkout the head of the pull request instead of the merge commit.
       - run: git checkout HEAD^2
-        if: ${{ github.event_name == 'pull_request' }}      
-      # Java 8 required by ScanCentral Client and FoD Uploader(Univeral CI Tool)
-      - name: Setup Java
-        uses: actions/setup-java@v1
+        if: ${{ github.event_name == 'pull_request' }}
+    
+      - name: Run Fortify on Demand SAST & SCA Scan
+        uses: fortify/github-action@2dbcae155c2790152920329a591aa4db77257c20 #v2.0.0
         with:
-          java-version: 1.8
-      
-      # ScanCentral Client documentation is located at https://www.microfocus.com/documentation/fortify-software-security-center/ 
-      - name: Download Fortify ScanCentral Client
-        uses: fortify/gha-setup-scancentral-client@v1
-      - name: Package Code + Dependencies
-        run: scancentral package -bt none -o package.zip
-      
-      # Start Fortify on Demand SAST scan and wait until results complete. For more information on FoDUploader commands, see https://github.com/fod-dev/fod-uploader-java
-      - name: Download Fortify on Demand Universal CI Tool
-        uses: fortify/gha-setup-fod-uploader@v1
-      - name: Perform SAST Scan
-        run: java -jar $FOD_UPLOAD_JAR -z package.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_UPLOADER_NOTES"
-        env: 
-          FOD_TENANT: ${{ secrets.FOD_TENANT }}  
+          sast-scan: true
+        env:
+          FOD_URL: "https://ams.fortify.com"
+          FOD_TENANT: ${{ secrets.FOD_TENANT }}
           FOD_USER: ${{ secrets.FOD_USER }}
-          FOD_PAT: ${{ secrets.FOD_PAT }}
-          FOD_RELEASE_ID: ${{ secrets.FOD_RELEASE_ID }}
-          FOD_URL: "https://ams.fortify.com/"
-          FOD_API_URL: "https://api.ams.fortify.com/"
-          FOD_UPLOADER_OPTS: "-ep 2 -pp 0 -I 1 -apf"
-          FOD_UPLOADER_NOTES: 'Triggered by GitHub Actions (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
+          FOD_PASSWORD: ${{ secrets.FOD_PAT }}
+          FOD_RELEASE: ${{ secrets.FOD_RELEASE_ID }}
+
+      # Java 8 required by ScanCentral Client and FoD Uploader(Univeral CI Tool)
+    #   - name: Setup Java
+    #     uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1
+    #     with:
+    #       java-version: 1.8
+      
+    #   # ScanCentral Client documentation is located at https://www.microfocus.com/documentation/fortify-software-security-center/ 
+    #   - name: Download Fortify ScanCentral Client
+    #     uses: fortify/gha-setup-scancentral-client@v1
+    #   - name: Package Code + Dependencies
+    #     run: scancentral package -bt none -o package.zip
+      
+    #   # Start Fortify on Demand SAST scan and wait until results complete. For more information on FoDUploader commands, see https://github.com/fod-dev/fod-uploader-java
+    #   - name: Download Fortify on Demand Universal CI Tool
+    #     uses: fortify/gha-setup-fod-uploader@v1
+    #   - name: Perform SAST Scan
+    #     run: java -jar $FOD_UPLOAD_JAR -z package.zip -aurl $FOD_API_URL -purl $FOD_URL -rid "$FOD_RELEASE_ID" -tc "$FOD_TENANT" -uc "$FOD_USER" "$FOD_PAT" $FOD_UPLOADER_OPTS -n "$FOD_UPLOADER_NOTES"
+    #     env: 
+    #       FOD_TENANT: ${{ secrets.FOD_TENANT }}  
+    #       FOD_USER: ${{ secrets.FOD_USER }}
+    #       FOD_PAT: ${{ secrets.FOD_PAT }}
+    #       FOD_RELEASE_ID: ${{ secrets.FOD_RELEASE_ID }}
+    #       FOD_URL: "https://ams.fortify.com/"
+    #       FOD_API_URL: "https://api.ams.fortify.com/"
+    #       FOD_UPLOADER_OPTS: "-ep 2 -pp 0 -I 1 -apf"
+    #       FOD_UPLOADER_NOTES: 'Triggered by GitHub Actions (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})'
       
       ###
       # These remaining steps require GitHub Enterprise


### PR DESCRIPTION
# Motivation
Avoid supply-chain attacks in third-party dependencies where a malicious commit can be re-tagged and used by victims in their GitHub actions.

# Summary of Changes
- Pinned specific SHA commits for each third-party GitHub action used (with release versions appended as a comment). In some cases the version of the action in use has been upgraded.
- Update deprecated Fortify actions to use their new all-in-one GH Action: https://github.com/marketplace/actions/fortify-ast-scan#ssc-fcli-actions