### PR TITLE
chore: add team-commander as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@onebrief/team-commander


### PR DESCRIPTION
Adding team-commander as CODEOWNERS for the repo.