### PR TITLE
chore: bump go version to patch high vuln CVE [CDR-206]

### DIFF
--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.24.2
+ARG GOLANG_VERSION=1.24.4
 ARG GOTENBERG_VERSION=8.21.1
 ARG BASE_IMAGE=harbor.onebrief.tools/cgr.dev/onebrief.com/gotenberg
 ARG UNOCONVERTER_BIN_PATH=/usr/bin/unoconv

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gotenberg/gotenberg/v8
 
-go 1.24.0
+go 1.24.4
 
 require (
 	github.com/alexliesenfeld/health v0.8.0

--- a/scripts/build.cmd
+++ b/scripts/build.cmd
@@ -1,14 +1,14 @@
 set DOCKER_REPO_GH=ghcr.io/onebrief
 set GOTENBERG_VERSION=8.21.1
 
-set GOLANG_VERSION=1.24.0
+set GOLANG_VERSION=1.24.4
 set DOCKER_REPOSITORY=onebrief
 set GOTENBERG_USER_GID=1001
 set GOTENBERG_USER_UID=1001
 :: See https://github.com/googlefonts/noto-emoji/releases.
-set NOTO_COLOR_EMOJI_VERSION=v2.047 
+set NOTO_COLOR_EMOJI_VERSION=v2.047
 :: See https://gitlab.com/pdftk-java/pdftk/-/releases - Binary package.
-set PDFTK_VERSION=v3.3.3 
+set PDFTK_VERSION=v3.3.3
 
 
 @REM -t %DOCKER_REPO_GH%/gotenberg:latest ^
@@ -21,4 +21,3 @@ docker build ^
   --platform linux/amd64 ^
   -t %DOCKER_REPO_GH%/gotenberg:%GOTENBERG_VERSION% ^
   -f build/Dockerfile.bc .
-


### PR DESCRIPTION
* https://avd.aquasec.com/nvd/2025/cve-2025-22874/