### PR TITLE
fix: Re-enable WebGL in Gotenberg

### DIFF
--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -86,7 +86,7 @@ func (b *chromiumBrowser) Start(logger *zap.Logger) error {
 		// See:
 		// https://github.com/gotenberg/gotenberg/issues/327
 		// https://github.com/chromedp/chromedp/issues/904
-		chromedp.DisableGPU,
+		// chromedp.DisableGPU,
 		// See:
 		// https://github.com/puppeteer/puppeteer/issues/661
 		// https://github.com/puppeteer/puppeteer/issues/2410


### PR DESCRIPTION
Forcibly turn on GPUs for our headless instance.