### PR TITLE
fix: missing env var

### DIFF
--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -39,6 +39,7 @@ COPY cve-fixes/cve-2012-5639/registrymodifications.xcu ~/.config/libreoffice/4/u
 # puts back in these env vars which are seemingly missing in the 8.15.3 chainguard base
 # they likely baked them into the code...
 ENV CHROMIUM_BIN_PATH=/usr/bin/chromium
+ENV CHROMIUM_HYPHEN_DATA_DIR_PATH=/opt/gotenberg/chromium-hyphen-data
 ENV LIBREOFFICE_BIN_PATH=/usr/lib/libreoffice/program/soffice.bin
 ENV UNOCONVERTER_BIN_PATH=$UNOCONVERTER_BIN_PATH
 ENV PDFTK_BIN_PATH=/usr/bin/pdftk


### PR DESCRIPTION
8.24 merge missed copying an env variable into our custom Dockerfile