### PR TITLE
chore: update to use more recent golang version

### DIFF
--- a/build/Dockerfile.bc
+++ b/build/Dockerfile.bc
@@ -1,4 +1,4 @@
-ARG GOLANG_VERSION=1.25.0
+ARG GOLANG_VERSION=1.25.2
 ARG GOTENBERG_VERSION=8.24.0
 ARG BASE_IMAGE=harbor.onebrief.tools/cgr.dev/onebrief.com/gotenberg
 ARG UNOCONVERTER_BIN_PATH=/usr/bin/unoconv


### PR DESCRIPTION
We want to build on a more recent GoLang release.