### PR TITLE
fix: disable Chrome crash reporter for restricted security contexts

### DIFF
--- a/pkg/modules/chromium/browser.go
+++ b/pkg/modules/chromium/browser.go
@@ -106,6 +106,10 @@ func (b *chromiumBrowser) Start(logger *zap.Logger) error {
 		chromedp.Flag("disable-dev-shm-usage", true),
 		// See https://github.com/gotenberg/gotenberg/issues/1293.
 		chromedp.Flag("disable-component-update", false),
+		// Disable crash reporter/breakpad to avoid the "chrome_crashpad_handler: --database is required"
+		// error in containers with restricted security contexts (e.g. ones with drop ALL capabilities).
+		chromedp.Flag("disable-crash-reporter", true),
+		chromedp.Flag("disable-breakpad", true),
 	)
 
 	if b.arguments.allowInsecureLocalhost {


### PR DESCRIPTION
## Changes
  - Adds `disable-crash-reporter` and `disable-breakpad` Chrome flags to prevent the error "`chrome_crashpad_handler: --database is required`" in containers with restricted security contexts

## Context

In environments like Palantir's Apollo Mission Manager that enforce `capabilities.drop: ALL` with restricted `PodSecurityStandard`, Chrome's crash handler spawns on startup but fails because it lacks the required capabilities. This kills the Chrome process, preventing Gotenberg from running and rendering PDFs.

These flags disable the crash handler entirely. Chrome functions normally without it.

No impact on standard (non-restricted) deployments.