### PR TITLE
chore: empty commit to trigger new pr image

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -63,3 +63,4 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+


### PR DESCRIPTION
NGC2 needs new/unique image tags. This PR trigger builds us an image that pulls a fresh gotenberg image that doesn't have CRIT's for:

```
Affected packages
py3-pip-wheel
Fixed version
26.1.1-r0
Vulnerable versions
26.0.1-r2

onebrief/gotenberg:pr-85
```